### PR TITLE
refact: not using dot inside symbols

### DIFF
--- a/src/codes/clj/docs/frontend/panels/definition/view.cljs
+++ b/src/codes/clj/docs/frontend/panels/definition/view.cljs
@@ -28,12 +28,12 @@
            :withBorder true
            :shadow "sm"}
 
-    ($ Card.Section {:withBorder true :inheritPadding true :py "sm"}
+    ($ (-> Card .-Section) {:withBorder true :inheritPadding true :py "sm"}
       ($ Title {:id "card-definition-title" :order 2}
         (:name definition)))
 
     (when (or added deprecated macro private)
-      ($ Card.Section {:withBorder true :inheritPadding true :py "sm"}
+      ($ (-> Card .-Section) {:withBorder true :inheritPadding true :py "sm"}
         ($ Group {:id "card-definition-metadata"
                   :justify "flex-start"}
           ($ Title {:order 6} "Metadata")
@@ -48,7 +48,7 @@
           (when private
             ($ Badge {:variant "light" :color "gray"} "private")))))
 
-    ($ Card.Section {:withBorder true :inheritPadding true :py "sm"}
+    ($ (-> Card .-Section) {:withBorder true :inheritPadding true :py "sm"}
       ($ Group {:justify "space-between"}
         ($ Group
           ($ Title {:order 6} "Source")
@@ -58,10 +58,10 @@
           ($ Title {:order 6} "Defined by")
           ($ Text defined-by))))
 
-    ($ Card.Section {:withBorder true :inheritPadding true :py "sm"}
+    ($ (-> Card .-Section) {:withBorder true :inheritPadding true :py "sm"}
       ($ Grid {:justify "space-between"}
         (when arglist-strs
-          ($ Grid.Col {:span 12}
+          ($ (-> Grid .-Col) {:span 12}
             ($ Title {:order 6} "Arguments")
             (map
               #($ Group {:key (str %) :my "sm"}
@@ -75,7 +75,7 @@
                      ($ Text {:span true :size "sm"} ")"))))
               arglist-strs)))
         (when doc
-          ($ Grid.Col {:span 12}
+          ($ (-> Grid .-Col) {:span 12}
             ($ Title {:order 6} "Doc")
             ($ Code {:style #js {:fontSize "var(--mantine-font-size-sm)"}
                      :block true}

--- a/src/codes/clj/docs/frontend/panels/definition/view/editor.cljs
+++ b/src/codes/clj/docs/frontend/panels/definition/view/editor.cljs
@@ -12,15 +12,15 @@
                             placeholder]}]
   (let [[text-body set-text-body] (hooks/use-state body)]
     ($ Grid {:data-testid "editor-base" :py py :align "center"}
-      ($ Grid.Col {:span 12}
+      ($ (-> Grid .-Col) {:span 12}
         ($ previewer {:text text-body
                       :set-text set-text-body
                       :placeholder placeholder}))
 
-      ($ Grid.Col {:span #js {:base 12 :md 8}}
+      ($ (-> Grid .-Col) {:span #js {:base 12 :md 8}}
         description)
 
-      ($ Grid.Col {:span #js {:base 12 :md 4}}
+      ($ (-> Grid .-Col) {:span #js {:base 12 :md 4}}
         ($ Group {:justify "flex-end" :gap "xs"}
           ($ Button {:id "editor-base-cancel-btn"
                      :data-testid "editor-base-cancel-btn"

--- a/src/codes/clj/docs/frontend/panels/definition/view/examples.cljs
+++ b/src/codes/clj/docs/frontend/panels/definition/view/examples.cljs
@@ -24,7 +24,7 @@
 (defnc avatar-editors [{:keys [editors]}]
   (let [shown-editors 3]
     (if (>= shown-editors (count editors))
-      ($ Avatar.Group
+      ($ (-> Avatar .-Group)
         (map
           #($ Tooltip {:key (str (:login %) (:edited-at %))
                        :label (str (:login %)
@@ -33,7 +33,7 @@
                        :withArrow true}
              ($ Avatar {:size "sm" :src (:avatar-url %)}))
           editors))
-      ($ Avatar.Group
+      ($ (-> Avatar .-Group)
         ($ Tooltip {:key "older-edits"
                     :label "Older revisions"
                     :withArrow true}
@@ -57,7 +57,7 @@
              :shadow "sm"
              :mb "sm"}
 
-      ($ Card.Section {:withBorder true :inheritPadding true :py "sm"}
+      ($ (-> Card .-Section) {:withBorder true :inheritPadding true :py "sm"}
         ($ Group {:gap "xs"}
           ($ avatar-editors {:editors editors})
 
@@ -80,9 +80,9 @@
                                              (state.examples/delete! example))})
                            :size "xs"} "delete"))))))
 
-      ($ Card.Section {:inheritPadding true :py 0}
+      ($ (-> Card .-Section) {:inheritPadding true :py 0}
         ($ Grid
-          ($ Grid.Col {:span 12}
+          ($ (-> Grid .-Col) {:span 12}
             (if show-example-editor
               ($ editor-example {:py "sm"
                                  :example example
@@ -102,14 +102,14 @@
              :withBorder true
              :shadow "sm"}
 
-      ($ Card.Section {:withBorder true :inheritPadding true :py "sm"}
+      ($ (-> Card .-Section) {:withBorder true :inheritPadding true :py "sm"}
         ($ Title {:id "card-examples-title" :order 4}
           (str (count examples) " examples")))
 
-      ($ Card.Section {:inheritPadding true
-                       :p "sm"}
+      ($ (-> Card .-Section) {:inheritPadding true
+                              :p "sm"}
         ($ Grid {:py 0}
-          ($ Grid.Col {:span 12}
+          ($ (-> Grid .-Col) {:span 12}
             (if (seq examples)
               (map #($ card-example {:key (:example-id %)
                                      :example %
@@ -119,7 +119,7 @@
               ($ Center
                 ($ Text "No examples"))))))
 
-      ($ Card.Section {:inheritPadding true :pb "sm"}
+      ($ (-> Card .-Section) {:inheritPadding true :pb "sm"}
         (if user
           (if show-new-example-editor
             ($ editor-example {:example nil

--- a/src/codes/clj/docs/frontend/panels/definition/view/notes.cljs
+++ b/src/codes/clj/docs/frontend/panels/definition/view/notes.cljs
@@ -33,7 +33,7 @@
              :shadow "sm"
              :mb "sm"}
 
-      ($ Card.Section {:withBorder true :inheritPadding true :py "sm"}
+      ($ (-> Card .-Section) {:withBorder true :inheritPadding true :py "sm"}
         ($ Group {:gap "xs"}
           ($ Tooltip {:label (:login author) :withArrow true}
             ($ Avatar {:size "sm" :src (:avatar-url author)}))
@@ -55,9 +55,9 @@
                                            (state.notes/delete! note))})
                          :size "xs"} "delete")))))
 
-      ($ Card.Section {:inheritPadding true :py 0}
+      ($ (-> Card .-Section) {:inheritPadding true :py 0}
         ($ Grid
-          ($ Grid.Col {:span 12}
+          ($ (-> Grid .-Col) {:span 12}
             (if show-note-editor
               ($ editor-note {:py "sm"
                               :note note
@@ -77,14 +77,14 @@
              :withBorder true
              :shadow "sm"}
 
-      ($ Card.Section {:withBorder true :inheritPadding true :py "sm"}
+      ($ (-> Card .-Section) {:withBorder true :inheritPadding true :py "sm"}
         ($ Title {:id "card-notes-title" :order 4}
           (str (count notes) " notes")))
 
-      ($ Card.Section {:inheritPadding true
-                       :p "sm"}
+      ($ (-> Card .-Section) {:inheritPadding true
+                              :p "sm"}
         ($ Grid {:py 0}
-          ($ Grid.Col {:span 12}
+          ($ (-> Grid .-Col) {:span 12}
             (if (seq notes)
               (map #($ card-note {:key (:note-id %)
                                   :note %
@@ -94,7 +94,7 @@
               ($ Center
                 ($ Text "No notes"))))))
 
-      ($ Card.Section {:inheritPadding true :pb "sm"}
+      ($ (-> Card .-Section) {:inheritPadding true :pb "sm"}
         (if user
           (if show-new-note-editor
             ($ editor-note {:note nil

--- a/src/codes/clj/docs/frontend/panels/definition/view/see_alsos.cljs
+++ b/src/codes/clj/docs/frontend/panels/definition/view/see_alsos.cljs
@@ -30,7 +30,7 @@
         (search-fetch state.see-alsos/search-results (or debounced "") query-limit)))
 
     ($ Grid {:data-testid "editor-see-also" :align "center"}
-      ($ Grid.Col {:span 12}
+      ($ (-> Grid .-Col) {:span 12}
         ($ Combobox
           {:onOptionSubmit (fn [option-value option-props]
                              (set-definition-id-to (.-id option-props))
@@ -38,7 +38,7 @@
                              (.closeDropdown combobox))
            :withinPortal true
            :store combobox}
-          ($ Combobox.Target
+          ($ (-> Combobox .-Target)
             ($ TextInput {:id "editor-see-also-textarea"
                           :data-testid "editor-see-also-textarea"
                           :label "New see also"
@@ -57,19 +57,19 @@
                           :rightSection (when loading?
                                           ($ Loader {:size "md"}))}))
 
-          ($ Combobox.Dropdown
-            ($ Combobox.Options {:mah 200 :style #js {:overflowY "auto"}}
+          ($ (-> Combobox .-Dropdown)
+            ($ (-> Combobox .-Options) {:mah 200 :style #js {:overflowY "auto"}}
               (if-not (nil? (seq auto-complete-list))
                 (map (fn [{:keys [id name]}]
-                       ($ Combobox.Option {:value name :id id :key id}
+                       ($ (-> Combobox .-Option) {:value name :id id :key id}
                          (dom/div
                            ($ Title {:order 4} name)
                            ($ Text {:size "xs" :variant "dimmed"}
                              (str/replace id #"/0$" "")))))
                      auto-complete-list)
-                ($ Combobox.Empty "No results found"))))))
+                ($ (-> Combobox .-Empty) "No results found"))))))
 
-      ($ Grid.Col {:span 12}
+      ($ (-> Grid .-Col) {:span 12}
         ($ Group {:justify "flex-end" :gap "xs"}
           ($ Button {:id "editor-see-also-cancel-btn"
                      :data-testid "editor-see-also-cancel-btn"
@@ -94,18 +94,18 @@
              :shadow "sm"
              :mb "sm"}
 
-      ($ Card.Section {:component safe-anchor
-                       :href (str "/" id)
-                       :withBorder true
-                       :inheritPadding true
-                       :py "sm"}
+      ($ (-> Card .-Section) {:component safe-anchor
+                              :href (str "/" id)
+                              :withBorder true
+                              :inheritPadding true
+                              :py "sm"}
         ($ Group {:justify "space-between" :gap "xs"}
           ($ Title {:order 4} link-name)))
 
-      ($ Card.Section {:withBorder false
-                       :inheritPadding true
-                       :pt "xs"
-                       :pb "0"}
+      ($ (-> Card .-Section) {:withBorder false
+                              :inheritPadding true
+                              :pt "xs"
+                              :pb "0"}
         ($ Text {:size "sm" :fw "bold"}
           id))
 
@@ -137,25 +137,25 @@
              :withBorder true
              :shadow "sm"}
 
-      ($ Card.Section {:withBorder true :inheritPadding true :py "sm"}
+      ($ (-> Card .-Section) {:withBorder true :inheritPadding true :py "sm"}
         ($ Title {:id "card-see-alsos-title" :order 4}
           (str (count see-alsos) " see alsos")))
 
-      ($ Card.Section {:inheritPadding true
-                       :p "sm"}
+      ($ (-> Card .-Section) {:inheritPadding true
+                              :p "sm"}
         ($ Grid {:py 0 :gutter "xs"}
           (if (seq see-alsos)
-            (map #($ Grid.Col {:key (:see-also-id %)
-                               :span #js {:base 12 :sm 6}}
+            (map #($ (-> Grid .-Col) {:key (:see-also-id %)
+                                      :span #js {:base 12 :sm 6}}
                     ($ card-see-also {:see-also %
                                       :user user
                                       :set-delete-modal-fn set-delete-modal-fn}))
                  see-alsos)
-            ($ Grid.Col {:span 12}
+            ($ (-> Grid .-Col) {:span 12}
               ($ Center
                 ($ Text "No see alsos"))))))
 
-      ($ Card.Section {:inheritPadding true :pb "sm"}
+      ($ (-> Card .-Section) {:inheritPadding true :pb "sm"}
         (if user
           (if show-new-see-also-editor
             ($ editor-see-also {:definition-id (:id definition)

--- a/src/codes/clj/docs/frontend/panels/definitions/view.cljs
+++ b/src/codes/clj/docs/frontend/panels/definitions/view.cljs
@@ -61,7 +61,7 @@
       (when definitions
         ($ Grid {:data-testid "definition-lines-grid"}
           (map (fn [[group sub-definitions]]
-                 ($ Grid.Col {:key group}
+                 ($ (-> Grid .-Col) {:key group}
                    ($ definitions-grouped {:key (str "grouped-" group)
                                            :group group
                                            :sub-definitions sub-definitions})))

--- a/src/codes/clj/docs/frontend/panels/home/view.cljs
+++ b/src/codes/clj/docs/frontend/panels/home/view.cljs
@@ -7,7 +7,7 @@
 (defnc home []
   ($ Container {:p "sm"}
     ($ Grid {:id "why"}
-      ($ Grid.Col {:span 12}
+      ($ (-> Grid .-Col) {:span 12}
         (dom/section
           ($ Title {:order 1}
             ($ Anchor {:component "a"
@@ -25,7 +25,7 @@
                        :underline "never"
                        :href "https://clojure.org"}
               "Clojure programming language"))))
-      ($ Grid.Col {:span 12}
+      ($ (-> Grid .-Col) {:span 12}
         ($ Text {:size "xl" :style #js {:paddingTop "1rem"}}
           "Built on a tech stack featuring "
           ($ Text {:component "a" :href "https://github.com/lilactown/helix" :inherit true :fw 700} "helix")
@@ -36,27 +36,27 @@
           " on the backend.")))
 
     ($ Grid {:id "features"}
-      ($ Grid.Col {:span 12}
+      ($ (-> Grid .-Col) {:span 12}
         (dom/section
           (dom/h2 "Key Features")
           ($ Grid  {:grow true :gutter "lg"}
-            ($ Grid.Col {:span 4}
+            ($ (-> Grid .-Col) {:span 4}
               ($ Card {:shadow "sm" :padding "lg" :radius "lg" :style #js {:minHeight "14rem"}}
                 (dom/h3 "Comprehensive Documentation")
                 (dom/p "Explore in-depth documentation for a vast array of Clojure libraries.")))
-            ($ Grid.Col {:span 4}
+            ($ (-> Grid .-Col) {:span 4}
               ($ Card {:shadow "sm" :padding "lg" :radius "lg" :style #js {:minHeight "14rem"}}
                 (dom/h3 "Seamless Git Integration")
                 (dom/p "Documentation is directly parsed from their Git repositories.")))
-            ($ Grid.Col {:span 4}
+            ($ (-> Grid .-Col) {:span 4}
               ($ Card {:shadow "sm" :padding "lg" :radius "lg" :style #js {:minHeight "14rem"}}
                 (dom/h3 "Social Interaction")
                 (dom/p "Join a vibrant community of Clojure enthusiasts.")))
-            ($ Grid.Col {:span 4}
+            ($ (-> Grid .-Col) {:span 4}
               ($ Card {:shadow "sm" :padding "lg" :radius "lg" :style #js {:minHeight "14rem"}}
                 (dom/h3 "Extensive Search Capabilities")
                 (dom/p "Harness the power of Datalevin for lightning-fast full-text search.")))
-            ($ Grid.Col {:span 4}
+            ($ (-> Grid .-Col) {:span 4}
               ($ Card {:shadow "sm" :padding "lg" :radius "lg" :style #js {:minHeight "14rem"}}
                 (dom/h3 "Easy Contribution")
                 (dom/p "Become a part of the documentation ecosystem.")))))))))

--- a/src/codes/clj/docs/frontend/panels/namespaces/view.cljs
+++ b/src/codes/clj/docs/frontend/panels/namespaces/view.cljs
@@ -15,7 +15,7 @@
         card-namespaces (->> namespaces
                              (sort-by :name)
                              (map (fn [{:keys [id] :as props}]
-                                    ($ Grid.Col {:key id}
+                                    ($ (-> Grid .-Col) {:key id}
                                       ($ card-namespace {:& props})))))
         project-id (:id project)]
 

--- a/src/codes/clj/docs/frontend/panels/projects/view.cljs
+++ b/src/codes/clj/docs/frontend/panels/projects/view.cljs
@@ -30,15 +30,15 @@
                            (sort-by :artifact)
                            (map (fn [{:keys [id] :as props}]
                                   ($ card-project {:key id :& props}))))]
-    ($ Accordion.Item {:id (str "accordion-item-" id)
-                       :data-testid (str "accordion-item-" id)
-                       :key id :value id}
-      ($ Accordion.Control
+    ($ (-> Accordion .-Item) {:id (str "accordion-item-" id)
+                              :data-testid (str "accordion-item-" id)
+                              :key id :value id}
+      ($ (-> Accordion .-Control)
         ($ accordion-label {:label id
                             :image image
                             :urls urls
                             :count-projects count-projects}))
-      ($ Accordion.Panel
+      ($ (-> Accordion .-Panel)
         ($ Group {:justify "space-between"}
           project-cards)))))
 
@@ -46,7 +46,7 @@
   (let [{:keys [value loading?]} (use-flex document-projects-response)]
     ($ Container {:p "sm"}
       ($ Grid
-        ($ Grid.Col {:key "organization-title" :span 12}
+        ($ (-> Grid .-Col) {:key "organization-title" :span 12}
           (dom/section
             ($ Title {:order 1}
               "Projects by "
@@ -56,7 +56,7 @@
 
         ($ Space {:h "xl"})
 
-        ($ Grid.Col {:key "organization-list" :span 12}
+        ($ (-> Grid .-Col) {:key "organization-list" :span 12}
           ($ LoadingOverlay {:visible loading? :zIndex 1000 :overlayProps #js {:radius "sm" :blur 2}})
           ($ Accordion {:defaultValue "org.clojure"
                         :chevronPosition "right"

--- a/src/codes/clj/docs/frontend/panels/search/components.cljs
+++ b/src/codes/clj/docs/frontend/panels/search/components.cljs
@@ -14,35 +14,35 @@
 
 (defnc spotlight-modal
   [{:keys [query-limit debounced-query loading? items close-fn query] :as props}]
-  ($ Spotlight.Root {:data-testid "spotlight-modal-search-root"
-                     :& (dissoc props
-                                :query-limit
-                                :debounced-query
-                                :loading?
-                                :close-fn
-                                :items)}
+  ($ (-> Spotlight .-Root) {:data-testid "spotlight-modal-search-root"
+                            :& (dissoc props
+                                       :query-limit
+                                       :debounced-query
+                                       :loading?
+                                       :close-fn
+                                       :items)}
 
-    ($ Spotlight.Search {:data-testid "spotlight-modal-search-input"
-                         :placeholder "Search"
-                         :leftSection ($ IconSearch {:stroke 1.5})})
+    ($ (-> Spotlight .-Search) {:data-testid "spotlight-modal-search-input"
+                                :placeholder "Search"
+                                :leftSection ($ IconSearch {:stroke 1.5})})
 
-    ($ Spotlight.ActionsList
+    ($ (-> Spotlight .-ActionsList)
       (cond
-        loading? ($ Spotlight.Empty {:data-testid "spotlight-loading"
-                                     :key "spotlight-loading"}
+        loading? ($ (-> Spotlight .-Empty) {:data-testid "spotlight-loading"
+                                            :key "spotlight-loading"}
                    ($ Loader {:color "moonstone"}))
 
         (seq items) (->> items
                          (group-by :type)
                          (map
                           (fn [[type-key grouped-items]]
-                            ($ Spotlight.ActionsGroup
+                            ($ (-> Spotlight .-ActionsGroup)
                               {:data-testid (str "spotlight-actions-group" type-key)
                                :key (str "spotlight-actions-group" type-key)
                                :label (name type-key)}
                               (map
                                 (fn [{:keys [id name doc type]}]
-                                  ($ Spotlight.Action
+                                  ($ (-> Spotlight .-Action)
                                     {:data-testid (str "spotlight-action-" id)
                                      :key (str "spotlight-action-" id)
                                      :label name
@@ -66,17 +66,17 @@
         :else (if (and (zero? (count items))
                        (not (str/blank? query))
                        (= query debounced-query))
-                ($ Spotlight.Empty {:data-testid "spotlight-no-results"
-                                    :key "spotlight-no-results"}
+                ($ (-> Spotlight .-Empty) {:data-testid "spotlight-no-results"
+                                           :key "spotlight-no-results"}
                   "No results were found")
-                ($ Spotlight.Empty {:data-testid "spotlight-no-query"
-                                    :key "spotlight-no-query"}
+                ($ (-> Spotlight .-Empty) {:data-testid "spotlight-no-query"
+                                           :key "spotlight-no-query"}
                   "Search the documentation")))
 
       (when (and (>= (count items) query-limit)
                  (not loading?))
-        ($ Spotlight.Empty {:data-testid "spotlight-limit-reached"
-                            :key "spotlight-limit-reached"}
+        ($ (-> Spotlight .-Empty) {:data-testid "spotlight-limit-reached"
+                                   :key "spotlight-limit-reached"}
           ($ Button {:component "a"
                      :href (str "/search?q=" debounced-query)
                      :onClick close-fn}
@@ -110,20 +110,20 @@
              :shadow "sm"
              :padding "lg"}
 
-      ($ Card.Section {:component safe-anchor
-                       :href (str "/" id)
-                       :withBorder true
-                       :inheritPadding true
-                       :py "sm"}
+      ($ (-> Card .-Section) {:component safe-anchor
+                              :href (str "/" id)
+                              :withBorder true
+                              :inheritPadding true
+                              :py "sm"}
         ($ Group {:justify "space-between" :gap "xs"}
           ($ Title {:order 4} result-name)
           ($ Badge {:variant "light" :color "moonstone" :size "xs"}
             (name type))))
 
-      ($ Card.Section {:withBorder false
-                       :inheritPadding true
-                       :pt "xs"
-                       :pb "0"}
+      ($ (-> Card .-Section) {:withBorder false
+                              :inheritPadding true
+                              :pt "xs"
+                              :pb "0"}
         ($ Text {:size "xs" :fw "bold"}
           (str/replace id #"/0$" "")))
 

--- a/src/codes/clj/docs/frontend/panels/shell/view.cljs
+++ b/src/codes/clj/docs/frontend/panels/shell/view.cljs
@@ -22,5 +22,5 @@
                                   :logoff logoff-fn
                                   :links header-links
                                   :login-link login-link})
-      ($ AppShell.Main ($ children))
+      ($ (-> AppShell .-Main) ($ children))
       ($ shell.components/footer))))


### PR DESCRIPTION
https://cljs.github.io/api/syntax/dot

>Dots inside symbols accidentally work as a technical shortcut in ClojureScript, but this is not valid in Clojure.
> 
>     foo.bar.baz => foo.bar.baz (not recommended)
>     (foo.bar.baz) => foo.bar.baz() (not recommended)
> 
> Dots inside symbols are not recommended, as they are not detected by [:infer-externs](https://cljs.github.io/api/compiler-options/infer-externs). For example, no externs are generated for (foo.bar) if [^js foo](https://cljs.github.io/api/syntax/js-tag) is annotated.

Refactor using regex capturing groups in nvim:
`:%s/\$ \(\w*\)\.\(\w*\)/$ (-> \1 .-\2)/gc`