### PR TITLE
feat: env vars for production configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This file has two main functions:
 - Set configuration differences between local and deployed versions
   - `:base-url` base url that the http client will use to build the backend requests
   - `:github` informations used to do the login with github like `:client-id` and `:redirect-uri`
+- For the configuration values above, their values may be redefined at compile time if their corresponding environment 
+variables are present: `BASE_URL`, `CLIENT_ID` and `REDIRECT_URI`.
 
 ## Project
 [Check the project backlog, issues and ongoing tasks](https://github.com/orgs/clj-codes/projects/2)

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ This file has two main functions:
 - Set configuration differences between local and deployed versions
   - `:base-url` base url that the http client will use to build the backend requests
   - `:github` informations used to do the login with github like `:client-id` and `:redirect-uri`
-- For the configuration values above, their values may be redefined at compile time if their corresponding environment 
-variables are present: `BASE_URL`, `CLIENT_ID` and `REDIRECT_URI`.
+- For the configuration values above, their values may be redefined at [compile time](https://shadow-cljs.github.io/docs/UsersGuide.html#closure-defines) if their corresponding [environment 
+variables](https://shadow-cljs.github.io/docs/UsersGuide.html#shadow-env) are present: `BASE_URL`, `CLIENT_ID` and `REDIRECT_URI`.
+
 
 ## Project
 [Check the project backlog, issues and ongoing tasks](https://github.com/orgs/clj-codes/projects/2)

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -13,7 +13,10 @@
                 :dev              {:modules {:core {:init-fn codes.clj.docs.frontend.dev.core/init}}}
                 :release          {:modules {:core {:init-fn codes.clj.docs.frontend.core/init}}}
                 :compiler-options {:warnings {:extending-base-js-type false}
-                                   :install-deps true}
+                                   :install-deps true
+                                   :closure-defines {codes.clj.docs.frontend.config/base-url #shadow/env ["BASE_URL"]
+                                                     codes.clj.docs.frontend.config/client-id #shadow/env ["CLIENT_ID"]
+                                                     codes.clj.docs.frontend.config/redirect-uri #shadow/env ["REDIRECT_URI"]}}
                 :build-hooks      [(codes.clj.docs.frontend.dev.shadow.hooks/hashed-files
                                     ["resources/public/css/app.css"
                                      "resources/public/js/core.js"])

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -14,9 +14,9 @@
                 :release          {:modules {:core {:init-fn codes.clj.docs.frontend.core/init}}}
                 :compiler-options {:warnings {:extending-base-js-type false}
                                    :install-deps true
-                                   :closure-defines {codes.clj.docs.frontend.config/base-url #shadow/env ["BASE_URL"]
-                                                     codes.clj.docs.frontend.config/client-id #shadow/env ["CLIENT_ID"]
-                                                     codes.clj.docs.frontend.config/redirect-uri #shadow/env ["REDIRECT_URI"]}}
+                                   :closure-defines {codes.clj.docs.frontend.config/BASE_URL #shadow/env ["BASE_URL"]
+                                                     codes.clj.docs.frontend.config/CLIENT_ID #shadow/env ["CLIENT_ID"]
+                                                     codes.clj.docs.frontend.config/REDIRECT_URI #shadow/env ["REDIRECT_URI"]}}
                 :build-hooks      [(codes.clj.docs.frontend.dev.shadow.hooks/hashed-files
                                     ["resources/public/css/app.css"
                                      "resources/public/js/core.js"])

--- a/src/codes/clj/docs/frontend/config.cljs
+++ b/src/codes/clj/docs/frontend/config.cljs
@@ -17,16 +17,20 @@
      :primaryColor "moonstone"
      :defaultRadius "md"})))
 
+(goog-define base-url "https://docs-backend.fly.dev/api/")
+(goog-define client-id "46d86692f00ed9c613a1")
+(goog-define redirect-ui "https://docs.clj.codes/github-callback")
+
 (def config
   (let [debug? goog.DEBUG]
     {:debug? debug?
      :base-url (if debug?
                  "http://localhost:3001/api/"
-                 "https://docs-backend.fly.dev/api/")
+                 base-url)
      :github {:login-url "https://github.com/login/oauth/authorize"
               :client-id (if debug?
                            "e2e06123b7ca69a6150a"
-                           "46d86692f00ed9c613a1")
+                           client-id)
               :redirect-uri (if debug?
                               "http://localhost:5000/github-callback"
-                              "https://docs.clj.codes/github-callback")}}))
+                              redirect-ui)}}))

--- a/src/codes/clj/docs/frontend/config.cljs
+++ b/src/codes/clj/docs/frontend/config.cljs
@@ -17,20 +17,20 @@
      :primaryColor "moonstone"
      :defaultRadius "md"})))
 
-(goog-define base-url "https://docs-backend.fly.dev/api/")
-(goog-define client-id "46d86692f00ed9c613a1")
-(goog-define redirect-uri "https://docs.clj.codes/github-callback")
+(goog-define BASE_URL "https://docs-backend.fly.dev/api/")
+(goog-define CLIENT_ID "46d86692f00ed9c613a1")
+(goog-define REDIRECT_URI "https://docs.clj.codes/github-callback")
 
 (def config
   (let [debug? goog.DEBUG]
     {:debug? debug?
      :base-url (if debug?
                  "http://localhost:3001/api/"
-                 base-url)
+                 BASE_URL)
      :github {:login-url "https://github.com/login/oauth/authorize"
               :client-id (if debug?
                            "e2e06123b7ca69a6150a"
-                           client-id)
+                           CLIENT_ID)
               :redirect-uri (if debug?
                               "http://localhost:5000/github-callback"
-                              redirect-uri)}}))
+                              REDIRECT_URI)}}))

--- a/src/codes/clj/docs/frontend/config.cljs
+++ b/src/codes/clj/docs/frontend/config.cljs
@@ -19,7 +19,7 @@
 
 (goog-define base-url "https://docs-backend.fly.dev/api/")
 (goog-define client-id "46d86692f00ed9c613a1")
-(goog-define redirect-ui "https://docs.clj.codes/github-callback")
+(goog-define redirect-uri "https://docs.clj.codes/github-callback")
 
 (def config
   (let [debug? goog.DEBUG]
@@ -33,4 +33,4 @@
                            client-id)
               :redirect-uri (if debug?
                               "http://localhost:5000/github-callback"
-                              redirect-ui)}}))
+                              redirect-uri)}}))


### PR DESCRIPTION
This PR allows configuration settings in non-debug mode to be set as environment variables.
It employs the [goog-define](https://cljs.github.io/api/cljs.core/goog-define) macro to set the default production values at compile time, thereby maintaining the current behavior. Additionally, it introduces the `#shadow/env` tag in `shadow-cljs.edn`, which enables these values to be overwritten by environment variables.

