### PR TITLE
feat: chromium headless no-sandbox mode

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,13 @@
 module.exports = function (config) {
     config.set({
-        browsers: ['ChromiumHeadless'],
+        browsers: ['ChromiumHeadlessNoSandbox'],
+        customLaunchers: {
+        // This will allow CI pipelines to run karma tests as root
+        ChromiumHeadlessNoSandbox: {
+            base: 'ChromiumHeadless',
+            flags: ['--no-sandbox']
+          }
+        },
         // The directory where the output file lives
         basePath: 'resources/tests',
         // The file itself


### PR DESCRIPTION
Many CI pipelines run their tasks as root, but this is not possible with ChromiumHeadless by default:
[Issue #158](https://github.com/karma-runner/karma-chrome-launcher/issues/158)

This PR changes `karma.conf.js` to run ChromiumHeadless in `--no-sandbox` mode.