### PR TITLE
feat: google analytics

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -16,7 +16,8 @@
                                    :install-deps true
                                    :closure-defines {codes.clj.docs.frontend.config/BASE_URL #shadow/env ["BASE_URL"]
                                                      codes.clj.docs.frontend.config/CLIENT_ID #shadow/env ["CLIENT_ID"]
-                                                     codes.clj.docs.frontend.config/REDIRECT_URI #shadow/env ["REDIRECT_URI"]}}
+                                                     codes.clj.docs.frontend.config/REDIRECT_URI #shadow/env ["REDIRECT_URI"]
+                                                     codes.clj.docs.frontend.infra.analytics/GA_TAG_ID #shadow/env ["GA_TAG_ID"]}}
                 :build-hooks      [(codes.clj.docs.frontend.dev.shadow.hooks/hashed-files
                                     ["resources/public/css/app.css"
                                      "resources/public/js/core.js"])

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -17,7 +17,7 @@
                                    :closure-defines {codes.clj.docs.frontend.config/BASE_URL #shadow/env ["BASE_URL"]
                                                      codes.clj.docs.frontend.config/CLIENT_ID #shadow/env ["CLIENT_ID"]
                                                      codes.clj.docs.frontend.config/REDIRECT_URI #shadow/env ["REDIRECT_URI"]
-                                                     codes.clj.docs.frontend.infra.analytics/GA_TAG_ID #shadow/env ["GA_TAG_ID"]}}
+                                                     codes.clj.docs.frontend.config/GA_TAG_ID #shadow/env ["GA_TAG_ID"]}}
                 :build-hooks      [(codes.clj.docs.frontend.dev.shadow.hooks/hashed-files
                                     ["resources/public/css/app.css"
                                      "resources/public/js/core.js"])

--- a/src/codes/clj/docs/frontend/config.cljs
+++ b/src/codes/clj/docs/frontend/config.cljs
@@ -20,10 +20,14 @@
 (goog-define BASE_URL "https://docs-backend.fly.dev/api/")
 (goog-define CLIENT_ID "46d86692f00ed9c613a1")
 (goog-define REDIRECT_URI "https://docs.clj.codes/github-callback")
+(goog-define GA_TAG_ID "")
 
 (def config
   (let [debug? goog.DEBUG]
     {:debug? debug?
+     :ga-tag-id (if debug?
+                  ""
+                  GA_TAG_ID)
      :base-url (if debug?
                  "http://localhost:3001/api/"
                  BASE_URL)

--- a/src/codes/clj/docs/frontend/core.cljs
+++ b/src/codes/clj/docs/frontend/core.cljs
@@ -2,6 +2,7 @@
   (:require ["@mantine/core" :refer [MantineProvider]]
             ["react-dom/client" :as rdom]
             [codes.clj.docs.frontend.config :refer [theme]]
+            [codes.clj.docs.frontend.infra.analytics :refer [google-analytics]]
             [codes.clj.docs.frontend.infra.flex.hook :refer [use-flex]]
             [codes.clj.docs.frontend.infra.helix :refer [defnc]]
             [codes.clj.docs.frontend.infra.routes.core :refer [init-routes!]]
@@ -25,5 +26,6 @@
   (.render root ($ app)))
 
 (defn ^:export init []
+  (google-analytics)
   (init-routes!)
   (render))

--- a/src/codes/clj/docs/frontend/infra/analytics.cljs
+++ b/src/codes/clj/docs/frontend/infra/analytics.cljs
@@ -1,6 +1,6 @@
 (ns codes.clj.docs.frontend.infra.analytics
-  (:require [codes.clj.docs.frontend.infra.system.state :as system.state]
-            [clojure.string :as string]))
+  (:require [clojure.string :as string]
+            [codes.clj.docs.frontend.infra.system.state :as system.state]))
 
 (defn google-tag-manager
   [ga-tag-id]

--- a/src/codes/clj/docs/frontend/infra/analytics.cljs
+++ b/src/codes/clj/docs/frontend/infra/analytics.cljs
@@ -1,0 +1,25 @@
+(ns codes.clj.docs.frontend.infra.analytics)
+
+(goog-define GA_TAG_ID "G-0123456789")
+
+(defn google-tag-manager
+  [ga-tag-id]
+  (let [script (js/document.createElement "script")]
+    (set! (.-src script) (str "https://www.googletagmanager.com/gtag/js?id="
+                              ga-tag-id))
+    (set! (.-async script) true)
+    (js/document.head.appendChild script)))
+
+(defn google-tag
+  [ga-tag-id]
+  (let [script (js/document.createElement "script")]
+    (set! (.-src script) (str "window.dataLayer = window.dataLayer || [];
+                               function gtag(){dataLayer.push(arguments);}
+                               gtag('js', new Date());
+
+                               gtag('config', '" ga-tag-id "');"))
+    (js/document.head.appendChild script)))
+
+(defn google-analytics []
+  (google-tag-manager GA_TAG_ID)
+  (google-tag GA_TAG_ID))

--- a/src/codes/clj/docs/frontend/infra/analytics.cljs
+++ b/src/codes/clj/docs/frontend/infra/analytics.cljs
@@ -1,6 +1,5 @@
-(ns codes.clj.docs.frontend.infra.analytics)
-
-(goog-define GA_TAG_ID "G-0123456789")
+(ns codes.clj.docs.frontend.infra.analytics
+  (:require [codes.clj.docs.frontend.infra.system.state :as system.state]))
 
 (defn google-tag-manager
   [ga-tag-id]
@@ -22,5 +21,7 @@
     (js/document.head.insertBefore script (.-nextSibling gtm-script))))
 
 (defn google-analytics []
-  (let [gtm-script (google-tag-manager GA_TAG_ID)]
-    (google-tag GA_TAG_ID gtm-script)))
+  (let [ga-tag-id (-> @system.state/components :config :ga-tag-id)]
+    (when (seq ga-tag-id)
+      (let [gtm-script (google-tag-manager ga-tag-id)]
+        (google-tag ga-tag-id gtm-script)))))

--- a/src/codes/clj/docs/frontend/infra/analytics.cljs
+++ b/src/codes/clj/docs/frontend/infra/analytics.cljs
@@ -1,5 +1,6 @@
 (ns codes.clj.docs.frontend.infra.analytics
-  (:require [codes.clj.docs.frontend.infra.system.state :as system.state]))
+  (:require [codes.clj.docs.frontend.infra.system.state :as system.state]
+            [clojure.string :as string]))
 
 (defn google-tag-manager
   [ga-tag-id]
@@ -20,8 +21,11 @@
                                gtag('config', '" ga-tag-id "');"))
     (js/document.head.insertBefore script (.-nextSibling gtm-script))))
 
+(defn ga-scripts
+  [ga-tag-id]
+  (when-not (string/blank? ga-tag-id)
+    (let [gtm-script (google-tag-manager ga-tag-id)]
+      (google-tag ga-tag-id gtm-script))))
+
 (defn google-analytics []
-  (let [ga-tag-id (-> @system.state/components :config :ga-tag-id)]
-    (when (seq ga-tag-id)
-      (let [gtm-script (google-tag-manager ga-tag-id)]
-        (google-tag ga-tag-id gtm-script)))))
+  (ga-scripts (-> @system.state/components :config :ga-tag-id)))

--- a/src/codes/clj/docs/frontend/infra/analytics.cljs
+++ b/src/codes/clj/docs/frontend/infra/analytics.cljs
@@ -8,18 +8,19 @@
     (set! (.-src script) (str "https://www.googletagmanager.com/gtag/js?id="
                               ga-tag-id))
     (set! (.-async script) true)
-    (js/document.head.appendChild script)))
+    (js/document.head.prepend script)
+    script))
 
 (defn google-tag
-  [ga-tag-id]
+  [ga-tag-id gtm-script]
   (let [script (js/document.createElement "script")]
     (set! (.-src script) (str "window.dataLayer = window.dataLayer || [];
                                function gtag(){dataLayer.push(arguments);}
                                gtag('js', new Date());
 
                                gtag('config', '" ga-tag-id "');"))
-    (js/document.head.appendChild script)))
+    (js/document.head.insertBefore script (.-nextSibling gtm-script))))
 
 (defn google-analytics []
-  (google-tag-manager GA_TAG_ID)
-  (google-tag GA_TAG_ID))
+  (let [gtm-script (google-tag-manager GA_TAG_ID)]
+    (google-tag GA_TAG_ID gtm-script)))

--- a/test/codes/clj/docs/frontend/test/infra/analytics_test.cljs
+++ b/test/codes/clj/docs/frontend/test/infra/analytics_test.cljs
@@ -1,0 +1,13 @@
+(ns codes.clj.docs.frontend.test.infra.analytics-test
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [clojure.string :as string]
+            [codes.clj.docs.frontend.infra.analytics :as analytics]))
+
+(deftest ga-scripts-test
+  (testing "not-blank GA_TAG_ID should return a script containing the tag id"
+    (let [ga-tag-id "G-0123456789"
+          ga-scripts (analytics/ga-scripts ga-tag-id)]
+      (is (instance? js/HTMLScriptElement ga-scripts))
+      (is (string/includes? (.-src ga-scripts) ga-tag-id))))
+  (testing "blank GA_TAG_ID should not return anything"
+    (is (nil? (analytics/ga-scripts "")))))


### PR DESCRIPTION
This PR sets up Google Analytics, by adding the necessary scripts to the HTML head element.
It uses a `GA_TAG_ID` that can be passed as a configuration variable.
When `GA_TAG_ID` is empty, it won't add any GA-related script.

Reference: [Google Tag Doc](https://developers.google.com/tag-platform/gtagjs/install)