### PR TITLE
fix: google-tag script

### DIFF
--- a/src/codes/clj/docs/frontend/infra/analytics.cljs
+++ b/src/codes/clj/docs/frontend/infra/analytics.cljs
@@ -14,11 +14,11 @@
 (defn google-tag
   [ga-tag-id gtm-script]
   (let [script (js/document.createElement "script")]
-    (set! (.-src script) (str "window.dataLayer = window.dataLayer || [];
-                               function gtag(){dataLayer.push(arguments);}
-                               gtag('js', new Date());
-
-                               gtag('config', '" ga-tag-id "');"))
+    (set! (.-text script) (str "window.dataLayer = window.dataLayer || [];
+                                function gtag(){dataLayer.push(arguments);}
+                                gtag('js', new Date());
+                                
+                                gtag('config', '" ga-tag-id "');"))
     (js/document.head.insertBefore script (.-nextSibling gtm-script))))
 
 (defn ga-scripts

--- a/test/codes/clj/docs/frontend/test/infra/analytics_test.cljs
+++ b/test/codes/clj/docs/frontend/test/infra/analytics_test.cljs
@@ -8,6 +8,6 @@
     (let [ga-tag-id "G-0123456789"
           ga-scripts (analytics/ga-scripts ga-tag-id)]
       (is (instance? js/HTMLScriptElement ga-scripts))
-      (is (string/includes? (.-src ga-scripts) ga-tag-id))))
+      (is (string/includes? (.-text ga-scripts) ga-tag-id))))
   (testing "blank GA_TAG_ID should not return anything"
     (is (nil? (analytics/ga-scripts "")))))


### PR DESCRIPTION
The `googe-tag` function resulted in a script with the JS code inside `src`, instead of its contents.
Therefore the script would have no effect.
This PR fixes the script creation passing the JS code as a `text` attribute.
It also fixes the test assertion related to this function.